### PR TITLE
Use assoc lists for records

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,6 @@ jobs:
           purescm run --main Test.Foldable.Main
           purescm run --main Test.Int.Main
           purescm run --main Test.Lazy.Main
-          purescm run --main Test.List.Main
           purescm run --main Test.Main
           purescm run --main Test.Minibench.Main
           purescm run --main Test.Number.Main

--- a/arrays/src/Data/Array.ss
+++ b/arrays/src/Data/Array.ss
@@ -139,7 +139,7 @@
   (define partitionImpl
     (lambda (f xs)
       (let-values ([(yes no) (srfi:214:flexvector-partition f xs)])
-        (rt:make-object (cons 'yes yes) (cons 'no no)))))
+        (list (cons 'yes yes) (cons 'no no)))))
 
   (define scanlImpl
     (lambda (f b xs)

--- a/arrays/src/Data/Array/ST.ss
+++ b/arrays/src/Data/Array/ST.ss
@@ -97,7 +97,7 @@
     (lambda (xs)
       (srfi:214:flexvector-map/index
         (lambda (i x)
-          (rt:make-object (cons 'index i) (cons 'value x)))
+          (list (cons 'index i) (cons 'value x)))
         xs)))
             
   (define copyImpl

--- a/prelude/src/Record/Unsafe.ss
+++ b/prelude/src/Record/Unsafe.ss
@@ -11,26 +11,22 @@
   (define unsafeHas
     (lambda (label)
       (lambda (rec)
-        (symbol-hashtable-contains? rec (string->symbol label)))))
+        (rt:record-has rec (string->symbol label)))))
 
   (define unsafeGet
     (lambda (label)
       (lambda (rec)
-        (rt:object-ref rec (string->symbol label)))))
+        (rt:record-ref rec (string->symbol label)))))
 
   (define unsafeSet
     (lambda (label)
       (lambda (value)
         (lambda (rec)
-          (let ([rec-copy (rt:object-copy rec)])
-            (rt:object-set! rec-copy (string->symbol label) value)
-            rec-copy)))))
+          (rt:record-set rec (string->symbol label) value)))))
 
   (define unsafeDelete
     (lambda (label)
       (lambda (rec)
-        (let ([rec-copy (rt:object-copy rec)])
-          (symbol-hashtable-delete! rec-copy (string->symbol label))
-          rec-copy))))
+        (rt:record-delete rec (string->symbol label)))))
 
 )

--- a/prelude/src/Record/Unsafe.ss
+++ b/prelude/src/Record/Unsafe.ss
@@ -27,6 +27,6 @@
   (define unsafeDelete
     (lambda (label)
       (lambda (rec)
-        (rt:record-delete rec (string->symbol label)))))
+        (rt:record-remove rec (string->symbol label)))))
 
 )

--- a/record/src/Record/Builder.purs
+++ b/record/src/Record/Builder.purs
@@ -23,7 +23,6 @@ import Record.Unsafe.Union (unsafeUnionFn)
 import Type.Proxy (Proxy)
 import Unsafe.Coerce (unsafeCoerce)
 
-foreign import copyRecord :: forall r1. Record r1 -> Record r1
 foreign import unsafeInsert :: forall a r1 r2. String -> a -> Record r1 -> Record r2
 foreign import unsafeModify :: forall a b r1 r2. String -> (a -> b) -> Record r1 -> Record r2
 foreign import unsafeDelete :: forall r1 r2. String -> Record r1 -> Record r2
@@ -47,7 +46,7 @@ newtype Builder a b = Builder (a -> b)
 
 -- | Build a record, starting from some other record.
 build :: forall r1 r2. Builder (Record r1) (Record r2) -> Record r1 -> Record r2
-build (Builder b) r1 = b (copyRecord r1)
+build (Builder b) r1 = b r1
 
 -- | Build a record from scratch.
 buildFromScratch :: forall r. Builder (Record ()) (Record r) -> Record r

--- a/record/src/Record/Builder.ss
+++ b/record/src/Record/Builder.ss
@@ -1,36 +1,31 @@
 (library (Record.Builder foreign)
-  (export copyRecord unsafeInsert unsafeModify unsafeDelete unsafeRename)
+  (export unsafeInsert unsafeModify unsafeDelete unsafeRename)
   (import (chezscheme)
           (prefix (purs runtime) rt:))
   
-  (define copyRecord rt:object-copy)
-
   (define unsafeInsert
     (lambda (l)
       (lambda (a)
         (lambda (rec)
-          (rt:object-set! rec (string->symbol l) a)
-          rec))))
+          (rt:record-set rec (string->symbol l) a)))))
 
   (define unsafeModify
     (lambda (l)
       (lambda (f)
         (lambda (rec)
-          (rt:object-set! rec (string->symbol l) (f (rt:object-ref rec (string->symbol l))))
-          rec))))
+          (rt:record-set rec (string->symbol l) (f (rt:record-ref rec (string->symbol l))))))))
 
   (define unsafeDelete
     (lambda (l)
       (lambda (rec)
-        (hashtable-delete! rec (string->symbol l))
-        rec)))
+        (rt:record-delete rec (string->symbol l)))))
 
   (define unsafeRename
     (lambda (l1)
       (lambda (l2)
         (lambda (rec)
-          (rt:object-set! rec (string->symbol l1) (rt:object-ref rec (string->symbol l2)))
-          (symbol-hashtable-delete! rec (string->symbol l1))
-          rec))))
+          (rt:record-delete
+            (rt:record-set rec (string->symbol l2) (rt:record-ref rec (string->symbol l1)))
+            (string->symbol l1))))))
 
   )

--- a/record/src/Record/Builder.ss
+++ b/record/src/Record/Builder.ss
@@ -18,13 +18,13 @@
   (define unsafeDelete
     (lambda (l)
       (lambda (rec)
-        (rt:record-delete rec (string->symbol l)))))
+        (rt:record-remove rec (string->symbol l)))))
 
   (define unsafeRename
     (lambda (l1)
       (lambda (l2)
         (lambda (rec)
-          (rt:record-delete
+          (rt:record-remove
             (rt:record-set rec (string->symbol l2) (rt:record-ref rec (string->symbol l1)))
             (string->symbol l1))))))
 

--- a/record/src/Record/Unsafe/Union.ss
+++ b/record/src/Record/Unsafe/Union.ss
@@ -3,18 +3,6 @@
   (import (chezscheme)
           (prefix (purs runtime) rt:))
 
-  (define (hashtable-for-each f ht)
-    (let-values ([(keys values) (hashtable-entries ht)])
-      (vector-for-each f keys values)))
-
-  (define unsafeUnionFn
-    (lambda (r1 r2)
-      (let ([r1copy (rt:object-copy r1)])
-        (hashtable-for-each
-          (lambda (key2 val2)
-            (if (not (symbol-hashtable-contains? r1copy key2))
-                (rt:object-set! r1copy key2 val2)))
-          r2)
-        r1copy)))
+  (define unsafeUnionFn append)
 
 )

--- a/record/test/Main.purs
+++ b/record/test/Main.purs
@@ -1,3 +1,9 @@
+-- @inline Record.Builder.build never
+-- @inline Record.Builder.insert never
+-- @inline Record.Builder.merge never
+-- @inline Record.Builder.delete never
+-- @inline Record.Builder.modify never
+-- @inline Record.Builder.rename never
 module Test.Record.Main where
 
 import Prelude

--- a/spago.lock
+++ b/spago.lock
@@ -1,0 +1,635 @@
+workspace:
+  packages:
+    arrays:
+      path: arrays
+      dependencies:
+        - bifunctors
+        - control
+        - foldable-traversable
+        - functions
+        - maybe
+        - nonempty
+        - partial
+        - prelude
+        - safe-coerce
+        - st
+        - tailrec
+        - tuples
+        - unfoldable
+        - unsafe-coerce
+      test_dependencies:
+        - assert
+        - console
+        - const
+        - minibench
+      build_plan:
+        - assert
+        - bifunctors
+        - console
+        - const
+        - contravariant
+        - control
+        - distributive
+        - effect
+        - either
+        - exists
+        - foldable-traversable
+        - functions
+        - functors
+        - identity
+        - integers
+        - invariant
+        - maybe
+        - minibench
+        - newtype
+        - nonempty
+        - numbers
+        - orders
+        - partial
+        - prelude
+        - profunctor
+        - refs
+        - safe-coerce
+        - st
+        - tailrec
+        - tuples
+        - type-equality
+        - unfoldable
+        - unsafe-coerce
+    assert:
+      path: assert
+      dependencies:
+        - console
+        - effect
+        - prelude
+      test_dependencies: []
+      build_plan:
+        - console
+        - effect
+        - prelude
+    console:
+      path: console
+      dependencies:
+        - effect
+        - prelude
+      test_dependencies: []
+      build_plan:
+        - effect
+        - prelude
+    control:
+      path: control
+      dependencies:
+        - newtype
+        - prelude
+      test_dependencies:
+        - effect
+      build_plan:
+        - effect
+        - newtype
+        - prelude
+        - safe-coerce
+        - unsafe-coerce
+    core:
+      path: ./
+      dependencies: []
+      test_dependencies: []
+      build_plan: []
+    effect:
+      path: effect
+      dependencies:
+        - prelude
+      test_dependencies: []
+      build_plan:
+        - prelude
+    exceptions:
+      path: exceptions
+      dependencies:
+        - effect
+        - either
+        - maybe
+        - prelude
+      test_dependencies: []
+      build_plan:
+        - control
+        - effect
+        - either
+        - invariant
+        - maybe
+        - newtype
+        - prelude
+        - safe-coerce
+        - unsafe-coerce
+    foldable-traversable:
+      path: foldable-traversable
+      dependencies:
+        - bifunctors
+        - const
+        - control
+        - either
+        - functors
+        - identity
+        - maybe
+        - newtype
+        - orders
+        - prelude
+        - tuples
+      test_dependencies:
+        - assert
+        - console
+        - integers
+        - unsafe-coerce
+      build_plan:
+        - assert
+        - bifunctors
+        - console
+        - const
+        - contravariant
+        - control
+        - distributive
+        - effect
+        - either
+        - exists
+        - functions
+        - functors
+        - identity
+        - integers
+        - invariant
+        - maybe
+        - newtype
+        - numbers
+        - orders
+        - partial
+        - prelude
+        - profunctor
+        - safe-coerce
+        - tuples
+        - type-equality
+        - unsafe-coerce
+    integers:
+      path: integers
+      dependencies:
+        - maybe
+        - numbers
+        - prelude
+      test_dependencies:
+        - assert
+        - console
+        - partial
+      build_plan:
+        - assert
+        - console
+        - control
+        - effect
+        - functions
+        - invariant
+        - maybe
+        - newtype
+        - numbers
+        - partial
+        - prelude
+        - safe-coerce
+        - unsafe-coerce
+    lazy:
+      path: lazy
+      dependencies:
+        - control
+        - effect
+        - foldable-traversable
+        - invariant
+        - prelude
+      test_dependencies:
+        - assert
+        - console
+        - effect
+      build_plan:
+        - assert
+        - bifunctors
+        - console
+        - const
+        - contravariant
+        - control
+        - distributive
+        - effect
+        - either
+        - exists
+        - foldable-traversable
+        - functions
+        - functors
+        - identity
+        - integers
+        - invariant
+        - maybe
+        - newtype
+        - numbers
+        - orders
+        - partial
+        - prelude
+        - profunctor
+        - safe-coerce
+        - tuples
+        - type-equality
+        - unsafe-coerce
+    minibench:
+      path: minibench
+      dependencies:
+        - console
+        - effect
+        - integers
+        - numbers
+        - partial
+        - prelude
+        - refs
+      test_dependencies:
+        - assert
+        - console
+        - effect
+      build_plan:
+        - assert
+        - console
+        - control
+        - effect
+        - functions
+        - integers
+        - invariant
+        - maybe
+        - newtype
+        - numbers
+        - partial
+        - prelude
+        - refs
+        - safe-coerce
+        - unsafe-coerce
+    numbers:
+      path: numbers
+      dependencies:
+        - functions
+        - maybe
+      test_dependencies:
+        - assert
+      build_plan:
+        - assert
+        - console
+        - control
+        - effect
+        - functions
+        - invariant
+        - maybe
+        - newtype
+        - prelude
+        - safe-coerce
+        - unsafe-coerce
+    prelude:
+      path: prelude
+      dependencies: []
+      test_dependencies: []
+      build_plan: []
+    record:
+      path: record
+      dependencies:
+        - functions
+        - prelude
+        - unsafe-coerce
+      test_dependencies:
+        - assert
+      build_plan:
+        - assert
+        - console
+        - effect
+        - functions
+        - prelude
+        - unsafe-coerce
+    st:
+      path: st
+      dependencies:
+        - partial
+        - prelude
+        - tailrec
+        - unsafe-coerce
+      test_dependencies:
+        - assert
+        - console
+        - partial
+      build_plan:
+        - assert
+        - bifunctors
+        - console
+        - const
+        - control
+        - effect
+        - either
+        - identity
+        - invariant
+        - maybe
+        - newtype
+        - partial
+        - prelude
+        - refs
+        - safe-coerce
+        - tailrec
+        - tuples
+        - unsafe-coerce
+  package_set:
+    address:
+      hash: sha256-ls6xyiStN1kPjkA/VPKwFe8e9uqcWZ1viySadgE7xcw=
+      url: https://raw.githubusercontent.com/purescm/purescm/f4b8670aad61398602fe8b61e7e4a33af1102320/package-sets/1.0.0.json
+    compiler: ">=0.15.10 <0.16.0"
+    content:
+      arrays:
+        git: https://github.com/purescm/purescript-arrays.git
+        ref: 39770954e86b5a5f311f470a718790210c4e37ff
+      assert:
+        git: https://github.com/purescm/purescript-assert.git
+        ref: bfef782e0e7a3fe041273c61e69c65dc54c1b2bf
+      bifunctors: 6.0.0
+      catenable-lists: 7.0.0
+      console:
+        git: https://github.com/purescm/purescript-console.git
+        ref: dc769b2f72215c141b53bfe65fc4c1b3c06d22b6
+        dependencies:
+          - effect
+          - prelude
+      const: 6.0.0
+      contravariant: 6.0.0
+      control:
+        git: https://github.com/purescm/purescript-control.git
+        ref: e9158b4499252aa976237a75468b876d283182eb
+      distributive: 6.0.0
+      effect:
+        git: https://github.com/purescm/purescript-effect.git
+        ref: a1fa3fd970ec82c05a664a4cae715b684cbe2253
+      either: 6.1.0
+      enums:
+        git: https://github.com/purescm/purescript-enums.git
+        ref: 5da5c4e4075ec64b75a9a3730ef98869d5d1fbba
+      exceptions:
+        git: https://github.com/purescm/purescript-exceptions.git
+        ref: a7c66a2c1b8a7d120efa7e33b9931ea4664b965a
+      exists: 6.0.0
+      filterable: 5.0.0
+      foldable-traversable:
+        git: https://github.com/purescm/purescript-foldable-traversable.git
+        ref: 6c7d0e5ea7931e46264adf0cd8c27395fd1d055b
+      free: 7.1.0
+      functions:
+        git: https://github.com/purescm/purescript-functions.git
+        ref: 94e0a9a3b7f831abebcb1bf65587fca03f04e034
+        dependencies:
+          - prelude
+      functors: 5.0.0
+      gen: 4.0.0
+      identity: 6.0.0
+      integers:
+        git: https://github.com/purescm/purescript-integers.git
+        ref: 0a9ef55a25a72a46b3c336b89eab429eee8b1f7b
+      invariant: 6.0.0
+      lazy:
+        git: https://github.com/purescm/purescript-lazy.git
+        ref: 383f0f9dd026b38a8fe4a8a8d8a4ecec543fbb2c
+      lists: 7.0.0
+      maybe: 6.0.0
+      minibench:
+        git: https://github.com/purescm/purescript-minibench.git
+        ref: f411a9023fe3ee685077d48940e59abce031a775
+      newtype: 5.0.0
+      nonempty: 7.0.0
+      numbers:
+        git: https://github.com/purescm/purescript-numbers.git
+        ref: bc6d165addfd08552054a6100088ae13f8c4f47f
+      ordered-collections: 3.1.1
+      orders: 6.0.0
+      parallel: 7.0.0
+      partial:
+        git: https://github.com/purescm/purescript-partial.git
+        ref: d8b6daf068e4aab0ad85a42d0f890ed37f416923
+        dependencies: []
+      prelude:
+        git: https://github.com/purescm/purescript-prelude.git
+        ref: 630d0da2a7416142b7c23646e75253e88b75bd38
+      profunctor: 6.0.0
+      record:
+        git: https://github.com/purescm/purescript-record.git
+        ref: 23d84398d3c6458be5033657a416e09dfc59f19c
+      refs:
+        git: https://github.com/purescm/purescript-refs.git
+        ref: 2ac82d3867e8ac02df03b6a04d635e0acd4b95db
+        dependencies:
+          - effect
+          - prelude
+      safe-coerce: 2.0.0
+      semirings: 7.0.0
+      st:
+        git: https://github.com/purescm/purescript-st.git
+        ref: 362137c0bad7dba398b3f2c7a00ed117fb8b8b99
+      tailrec: 6.1.0
+      transformers: 6.0.0
+      tuples: 7.0.0
+      type-equality: 4.0.1
+      unfoldable:
+        git: https://github.com/purescm/purescript-unfoldable.git
+        ref: 1cc7559e3d23537b02199d589c762087e0442f00
+      unsafe-coerce:
+        git: https://github.com/purescm/purescript-unsafe-coerce.git
+        ref: 20dbd7797e985b631459b8dbd4072cf3096ee1da
+        dependencies: []
+      validation: 6.0.0
+  extra_packages: {}
+packages:
+  bifunctors:
+    type: registry
+    version: 6.0.0
+    integrity: sha256-/gZwC9YhNxZNQpnHa5BIYerCGM2jeX9ukZiEvYxm5Nw=
+    dependencies:
+      - const
+      - either
+      - newtype
+      - prelude
+      - tuples
+  const:
+    type: registry
+    version: 6.0.0
+    integrity: sha256-tNrxDW8D8H4jdHE2HiPzpLy08zkzJMmGHdRqt5BQuTc=
+    dependencies:
+      - invariant
+      - newtype
+      - prelude
+  contravariant:
+    type: registry
+    version: 6.0.0
+    integrity: sha256-TP+ooAp3vvmdjfQsQJSichF5B4BPDHp3wAJoWchip6c=
+    dependencies:
+      - const
+      - either
+      - newtype
+      - prelude
+      - tuples
+  distributive:
+    type: registry
+    version: 6.0.0
+    integrity: sha256-HTDdmEnzigMl+02SJB88j+gAXDx9VKsbvR4MJGDPbOQ=
+    dependencies:
+      - identity
+      - newtype
+      - prelude
+      - tuples
+      - type-equality
+  either:
+    type: registry
+    version: 6.1.0
+    integrity: sha256-6hgTPisnMWVwQivOu2PKYcH8uqjEOOqDyaDQVUchTpY=
+    dependencies:
+      - control
+      - invariant
+      - maybe
+      - prelude
+  exists:
+    type: registry
+    version: 6.0.0
+    integrity: sha256-A0JQHpTfo1dNOj9U5/Fd3xndlRSE0g2IQWOGor2yXn8=
+    dependencies:
+      - unsafe-coerce
+  functions:
+    type: git
+    url: https://github.com/purescm/purescript-functions.git
+    rev: 94e0a9a3b7f831abebcb1bf65587fca03f04e034
+    dependencies:
+      - prelude
+  functors:
+    type: registry
+    version: 5.0.0
+    integrity: sha256-zfPWWYisbD84MqwpJSZFlvM6v86McM68ob8p9s27ywU=
+    dependencies:
+      - bifunctors
+      - const
+      - contravariant
+      - control
+      - distributive
+      - either
+      - invariant
+      - maybe
+      - newtype
+      - prelude
+      - profunctor
+      - tuples
+      - unsafe-coerce
+  identity:
+    type: registry
+    version: 6.0.0
+    integrity: sha256-4wY0XZbAksjY6UAg99WkuKyJlQlWAfTi2ssadH0wVMY=
+    dependencies:
+      - control
+      - invariant
+      - newtype
+      - prelude
+  invariant:
+    type: registry
+    version: 6.0.0
+    integrity: sha256-RGWWyYrz0Hs1KjPDA+87Kia67ZFBhfJ5lMGOMCEFoLo=
+    dependencies:
+      - control
+      - prelude
+  maybe:
+    type: registry
+    version: 6.0.0
+    integrity: sha256-5cCIb0wPwbat2PRkQhUeZO0jcAmf8jCt2qE0wbC3v2Q=
+    dependencies:
+      - control
+      - invariant
+      - newtype
+      - prelude
+  newtype:
+    type: registry
+    version: 5.0.0
+    integrity: sha256-gdrQu8oGe9eZE6L3wOI8ql/igOg+zEGB5ITh2g+uttw=
+    dependencies:
+      - prelude
+      - safe-coerce
+  nonempty:
+    type: registry
+    version: 7.0.0
+    integrity: sha256-54ablJZUHGvvlTJzi3oXyPCuvY6zsrWJuH/dMJ/MFLs=
+    dependencies:
+      - control
+      - foldable-traversable
+      - maybe
+      - prelude
+      - tuples
+      - unfoldable
+  orders:
+    type: registry
+    version: 6.0.0
+    integrity: sha256-nBA0g3/ai0euH8q9pSbGqk53W2q6agm/dECZTHcoink=
+    dependencies:
+      - newtype
+      - prelude
+  partial:
+    type: git
+    url: https://github.com/purescm/purescript-partial.git
+    rev: d8b6daf068e4aab0ad85a42d0f890ed37f416923
+    dependencies: []
+  profunctor:
+    type: registry
+    version: 6.0.0
+    integrity: sha256-99NzxFgTr4CGlCSRYG1kShL+JhYbihhHtbOk1/0R5zI=
+    dependencies:
+      - control
+      - distributive
+      - either
+      - exists
+      - invariant
+      - newtype
+      - prelude
+      - tuples
+  refs:
+    type: git
+    url: https://github.com/purescm/purescript-refs.git
+    rev: 2ac82d3867e8ac02df03b6a04d635e0acd4b95db
+    dependencies:
+      - effect
+      - prelude
+  safe-coerce:
+    type: registry
+    version: 2.0.0
+    integrity: sha256-a1ibQkiUcbODbLE/WAq7Ttbbh9ex+x33VCQ7GngKudU=
+    dependencies:
+      - unsafe-coerce
+  tailrec:
+    type: registry
+    version: 6.1.0
+    integrity: sha256-Xx19ECVDRrDWpz9D2GxQHHV89vd61dnXxQm0IcYQHGk=
+    dependencies:
+      - bifunctors
+      - effect
+      - either
+      - identity
+      - maybe
+      - partial
+      - prelude
+      - refs
+  tuples:
+    type: registry
+    version: 7.0.0
+    integrity: sha256-1rXgTomes9105BjgXqIw0FL6Fz1lqqUTLWOumhWec1M=
+    dependencies:
+      - control
+      - invariant
+      - prelude
+  type-equality:
+    type: registry
+    version: 4.0.1
+    integrity: sha256-Hs9D6Y71zFi/b+qu5NSbuadUQXe5iv5iWx0226vOHUw=
+    dependencies: []
+  unfoldable:
+    type: git
+    url: https://github.com/purescm/purescript-unfoldable.git
+    rev: 1cc7559e3d23537b02199d589c762087e0442f00
+    dependencies:
+      - foldable-traversable
+      - maybe
+      - partial
+      - prelude
+      - tuples
+  unsafe-coerce:
+    type: git
+    url: https://github.com/purescm/purescript-unsafe-coerce.git
+    rev: 20dbd7797e985b631459b8dbd4072cf3096ee1da
+    dependencies: []

--- a/spago.lock
+++ b/spago.lock
@@ -330,106 +330,122 @@ workspace:
         - unsafe-coerce
   package_set:
     address:
-      hash: sha256-ls6xyiStN1kPjkA/VPKwFe8e9uqcWZ1viySadgE7xcw=
-      url: https://raw.githubusercontent.com/purescm/purescm/f4b8670aad61398602fe8b61e7e4a33af1102320/package-sets/1.0.0.json
+      url: https://raw.githubusercontent.com/purescm/purescm/14a9497e54da7890374d19544629d4dbca62fa7d/package-sets/1.0.0.json
     compiler: ">=0.15.10 <0.16.0"
     content:
       arrays:
-        git: https://github.com/purescm/purescript-arrays.git
-        ref: 39770954e86b5a5f311f470a718790210c4e37ff
+        git: https://github.com/purescm/purescript-core.git
+        ref: 154d77119aa25b70f07f4b880dcba41ed811a852
+        subdir: arrays
       assert:
-        git: https://github.com/purescm/purescript-assert.git
-        ref: bfef782e0e7a3fe041273c61e69c65dc54c1b2bf
+        git: https://github.com/purescm/purescript-core.git
+        ref: 154d77119aa25b70f07f4b880dcba41ed811a852
+        subdir: assert
       bifunctors: 6.0.0
       catenable-lists: 7.0.0
       console:
-        git: https://github.com/purescm/purescript-console.git
-        ref: dc769b2f72215c141b53bfe65fc4c1b3c06d22b6
-        dependencies:
-          - effect
-          - prelude
+        git: https://github.com/purescm/purescript-core.git
+        ref: 154d77119aa25b70f07f4b880dcba41ed811a852
+        subdir: console
       const: 6.0.0
       contravariant: 6.0.0
       control:
-        git: https://github.com/purescm/purescript-control.git
-        ref: e9158b4499252aa976237a75468b876d283182eb
+        git: https://github.com/purescm/purescript-core.git
+        ref: 154d77119aa25b70f07f4b880dcba41ed811a852
+        subdir: control
       distributive: 6.0.0
       effect:
-        git: https://github.com/purescm/purescript-effect.git
-        ref: a1fa3fd970ec82c05a664a4cae715b684cbe2253
+        git: https://github.com/purescm/purescript-core.git
+        ref: 154d77119aa25b70f07f4b880dcba41ed811a852
+        subdir: effect
       either: 6.1.0
       enums:
-        git: https://github.com/purescm/purescript-enums.git
-        ref: 5da5c4e4075ec64b75a9a3730ef98869d5d1fbba
+        git: https://github.com/purescm/purescript-core.git
+        ref: 154d77119aa25b70f07f4b880dcba41ed811a852
+        subdir: enums
       exceptions:
-        git: https://github.com/purescm/purescript-exceptions.git
-        ref: a7c66a2c1b8a7d120efa7e33b9931ea4664b965a
+        git: https://github.com/purescm/purescript-core.git
+        ref: 154d77119aa25b70f07f4b880dcba41ed811a852
+        subdir: exceptions
       exists: 6.0.0
       filterable: 5.0.0
       foldable-traversable:
-        git: https://github.com/purescm/purescript-foldable-traversable.git
-        ref: 6c7d0e5ea7931e46264adf0cd8c27395fd1d055b
+        git: https://github.com/purescm/purescript-core.git
+        ref: 154d77119aa25b70f07f4b880dcba41ed811a852
+        subdir: foldable-traversable
       free: 7.1.0
       functions:
-        git: https://github.com/purescm/purescript-functions.git
-        ref: 94e0a9a3b7f831abebcb1bf65587fca03f04e034
+        git: https://github.com/purescm/purescript-core.git
+        ref: 154d77119aa25b70f07f4b880dcba41ed811a852
+        subdir: functions
         dependencies:
           - prelude
       functors: 5.0.0
       gen: 4.0.0
       identity: 6.0.0
       integers:
-        git: https://github.com/purescm/purescript-integers.git
-        ref: 0a9ef55a25a72a46b3c336b89eab429eee8b1f7b
+        git: https://github.com/purescm/purescript-core.git
+        ref: 154d77119aa25b70f07f4b880dcba41ed811a852
+        subdir: integers
       invariant: 6.0.0
       lazy:
-        git: https://github.com/purescm/purescript-lazy.git
-        ref: 383f0f9dd026b38a8fe4a8a8d8a4ecec543fbb2c
+        git: https://github.com/purescm/purescript-core.git
+        ref: 154d77119aa25b70f07f4b880dcba41ed811a852
+        subdir: lazy
       lists: 7.0.0
       maybe: 6.0.0
       minibench:
-        git: https://github.com/purescm/purescript-minibench.git
-        ref: f411a9023fe3ee685077d48940e59abce031a775
+        git: https://github.com/purescm/purescript-core.git
+        ref: 154d77119aa25b70f07f4b880dcba41ed811a852
+        subdir: minibench
       newtype: 5.0.0
       nonempty: 7.0.0
       numbers:
-        git: https://github.com/purescm/purescript-numbers.git
-        ref: bc6d165addfd08552054a6100088ae13f8c4f47f
+        git: https://github.com/purescm/purescript-core.git
+        ref: 154d77119aa25b70f07f4b880dcba41ed811a852
+        subdir: numbers
       ordered-collections: 3.1.1
       orders: 6.0.0
       parallel: 7.0.0
       partial:
-        git: https://github.com/purescm/purescript-partial.git
-        ref: d8b6daf068e4aab0ad85a42d0f890ed37f416923
+        git: https://github.com/purescm/purescript-core.git
+        ref: 154d77119aa25b70f07f4b880dcba41ed811a852
+        subdir: partial
         dependencies: []
       prelude:
-        git: https://github.com/purescm/purescript-prelude.git
-        ref: 630d0da2a7416142b7c23646e75253e88b75bd38
+        git: https://github.com/purescm/purescript-core.git
+        ref: 154d77119aa25b70f07f4b880dcba41ed811a852
+        subdir: prelude
       profunctor: 6.0.0
       record:
-        git: https://github.com/purescm/purescript-record.git
-        ref: 23d84398d3c6458be5033657a416e09dfc59f19c
+        git: https://github.com/purescm/purescript-core.git
+        ref: 154d77119aa25b70f07f4b880dcba41ed811a852
+        subdir: record
       refs:
-        git: https://github.com/purescm/purescript-refs.git
-        ref: 2ac82d3867e8ac02df03b6a04d635e0acd4b95db
+        git: https://github.com/purescm/purescript-core.git
+        ref: 154d77119aa25b70f07f4b880dcba41ed811a852
+        subdir: refs
         dependencies:
           - effect
           - prelude
       safe-coerce: 2.0.0
       semirings: 7.0.0
       st:
-        git: https://github.com/purescm/purescript-st.git
-        ref: 362137c0bad7dba398b3f2c7a00ed117fb8b8b99
+        git: https://github.com/purescm/purescript-core.git
+        ref: 154d77119aa25b70f07f4b880dcba41ed811a852
+        subdir: st
       tailrec: 6.1.0
       transformers: 6.0.0
       tuples: 7.0.0
       type-equality: 4.0.1
       unfoldable:
-        git: https://github.com/purescm/purescript-unfoldable.git
-        ref: 1cc7559e3d23537b02199d589c762087e0442f00
+        git: https://github.com/purescm/purescript-core.git
+        ref: 154d77119aa25b70f07f4b880dcba41ed811a852
+        subdir: unfoldable
       unsafe-coerce:
-        git: https://github.com/purescm/purescript-unsafe-coerce.git
-        ref: 20dbd7797e985b631459b8dbd4072cf3096ee1da
+        git: https://github.com/purescm/purescript-core.git
+        ref: 154d77119aa25b70f07f4b880dcba41ed811a852
+        subdir: unsafe-coerce
         dependencies: []
       validation: 6.0.0
   extra_packages: {}
@@ -489,8 +505,9 @@ packages:
       - unsafe-coerce
   functions:
     type: git
-    url: https://github.com/purescm/purescript-functions.git
-    rev: 94e0a9a3b7f831abebcb1bf65587fca03f04e034
+    url: https://github.com/purescm/purescript-core.git
+    rev: 154d77119aa25b70f07f4b880dcba41ed811a852
+    subdir: functions
     dependencies:
       - prelude
   functors:
@@ -563,8 +580,9 @@ packages:
       - prelude
   partial:
     type: git
-    url: https://github.com/purescm/purescript-partial.git
-    rev: d8b6daf068e4aab0ad85a42d0f890ed37f416923
+    url: https://github.com/purescm/purescript-core.git
+    rev: 154d77119aa25b70f07f4b880dcba41ed811a852
+    subdir: partial
     dependencies: []
   profunctor:
     type: registry
@@ -581,8 +599,9 @@ packages:
       - tuples
   refs:
     type: git
-    url: https://github.com/purescm/purescript-refs.git
-    rev: 2ac82d3867e8ac02df03b6a04d635e0acd4b95db
+    url: https://github.com/purescm/purescript-core.git
+    rev: 154d77119aa25b70f07f4b880dcba41ed811a852
+    subdir: refs
     dependencies:
       - effect
       - prelude
@@ -620,8 +639,9 @@ packages:
     dependencies: []
   unfoldable:
     type: git
-    url: https://github.com/purescm/purescript-unfoldable.git
-    rev: 1cc7559e3d23537b02199d589c762087e0442f00
+    url: https://github.com/purescm/purescript-core.git
+    rev: 154d77119aa25b70f07f4b880dcba41ed811a852
+    subdir: unfoldable
     dependencies:
       - foldable-traversable
       - maybe
@@ -630,6 +650,7 @@ packages:
       - tuples
   unsafe-coerce:
     type: git
-    url: https://github.com/purescm/purescript-unsafe-coerce.git
-    rev: 20dbd7797e985b631459b8dbd4072cf3096ee1da
+    url: https://github.com/purescm/purescript-core.git
+    rev: 154d77119aa25b70f07f4b880dcba41ed811a852
+    subdir: unsafe-coerce
     dependencies: []

--- a/spago.yaml
+++ b/spago.yaml
@@ -7,5 +7,4 @@ workspace:
     args:
       - build
   package_set:
-    url: https://raw.githubusercontent.com/purescm/purescm/f4b8670aad61398602fe8b61e7e4a33af1102320/package-sets/1.0.0.json
-    hash: sha256-ls6xyiStN1kPjkA/VPKwFe8e9uqcWZ1viySadgE7xcw=
+    url: https://raw.githubusercontent.com/purescm/purescm/14a9497e54da7890374d19544629d4dbca62fa7d/package-sets/1.0.0.json

--- a/spago.yaml
+++ b/spago.yaml
@@ -7,4 +7,4 @@ workspace:
     args:
       - build
   package_set:
-    url: https://raw.githubusercontent.com/purescm/purescm/14a9497e54da7890374d19544629d4dbca62fa7d/package-sets/1.0.0.json
+    url: https://raw.githubusercontent.com/purescm/purescm/3c0074b172a12bb9ee353c9ad6031d64d10b8b01/package-sets/1.0.0.json

--- a/st/src/Control/Monad/ST/Internal.ss
+++ b/st/src/Control/Monad/ST/Internal.ss
@@ -2,8 +2,7 @@
   (export map_ pure_ bind_ run while read for
           new foreach modifyImpl write)
 
-  (import (only (rnrs base) define lambda let quote if begin list cons = +)
-          (only (chezscheme) do)
+  (import (except (chezscheme) read write)
           (prefix (purs runtime srfi :214) srfi:214:)
           (prefix (purs runtime) rt:))
 
@@ -54,24 +53,24 @@
   (define new
     (lambda (val)
       (lambda ()
-        (rt:make-object (list (cons "value" val))))))
+        (box val))))
 
   (define read
     (lambda (ref)
       (lambda ()
-        (rt:object-ref ref "value"))))
+        (unbox ref))))
 
   (define modifyImpl
     (lambda (f)
       (lambda (ref)
-        (let ([t (f (rt:object-ref ref "value"))])
-          (rt:object-set! ref "value" (rt:object-ref t "state"))
-          (rt:object-ref t "value")))))
+        (let ([t (f (unbox ref))])
+          (set-box! ref (rt:record-ref t 'state))
+          (rt:record-ref t 'value)))))
 
   (define write
     (lambda (a)
       (lambda (ref)
         (lambda ()
-          (rt:object-set! ref "value" a)
+          (set-box! ref a)
           a))))
 )


### PR DESCRIPTION
Updates all libs to use assoc lists as records. These are the notable changes:

- `ST` now uses a `box` instead of an "object" with a single field named `value`.
- `Record.Builder` _doesn't_ use mutation anymore. The API doesn't allow switching the internal data structure used for the builder to use something else than whatever `Record` is. So for now we just use the default immutable `purescm` record API (assoc lists). I did remove the "copy" operation though, because that is no longer needed.

(CI won't pass because it relies on a released `purescm`)