### PR TITLE
Make Effect.Ref thread-safe

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,7 @@ jobs:
           purescm run --main Test.Array.Main
           purescm run --main Test.Console.Main
           purescm run --main Test.Control.Main
+          purescm run --main Test.Effect.Ref.Main
           purescm run --main Test.Foldable.Main
           purescm run --main Test.Int.Main
           purescm run --main Test.Lazy.Main

--- a/refs/src/Effect/Ref.ss
+++ b/refs/src/Effect/Ref.ss
@@ -12,12 +12,12 @@
   (scm:define _new
     (scm:lambda (v)
       (scm:lambda ()
-        (scm:list (scm:box v) (scm:make-mutex)))))
+        (scm:cons (scm:box v) (scm:make-mutex)))))
 
   (scm:define newWithSelf
     (scm:lambda (f)
       (scm:lambda ()
-        (scm:let ([ref (scm:list (scm:box (scm:quote ())) (scm:make-mutex))])
+        (scm:let ([ref (scm:cons (scm:box (scm:quote ())) (scm:make-mutex))])
           (scm:set-box! (scm:car ref) (f ref))
           ref))))
 
@@ -30,7 +30,7 @@
     (scm:lambda (f)
       (scm:lambda (ref)
         (scm:lambda ()
-          (scm:with-mutex (scm:cadr ref)
+          (scm:with-mutex (scm:cdr ref)
             (scm:let* ([t (f (scm:unbox (scm:car ref)))]
                        [v (rt:record-ref t (scm:quote state))])
               (scm:set-box! (scm:car ref) v)
@@ -40,7 +40,7 @@
     (scm:lambda (val)
       (scm:lambda (ref)
         (scm:lambda ()
-          (scm:with-mutex (scm:cadr ref)
+          (scm:with-mutex (scm:cdr ref)
             (scm:set-box! (scm:car ref) val))))))
 
 )

--- a/refs/src/Effect/Ref.ss
+++ b/refs/src/Effect/Ref.ss
@@ -6,38 +6,41 @@
           read
           modifyImpl
           write)
-  (import (prefix (chezscheme) scm:))
+  (import (prefix (chezscheme) scm:)
+          (prefix (purs runtime) rt:))
 
   (scm:define _new
     (scm:lambda (v)
       (scm:lambda ()
-        (scm:box v))))
+        (scm:list (scm:box v) (scm:make-mutex)))))
 
   (scm:define newWithSelf
     (scm:lambda (f)
       (scm:lambda ()
-        (scm:let ([ref (scm:box (scm:quote ()))])
-          (scm:set-box! ref (f ref))
+        (scm:let ([ref (scm:list (scm:box (scm:quote ())) (scm:make-mutex))])
+          (scm:set-box! (scm:car ref) (f ref))
           ref))))
 
   (scm:define read
     (scm:lambda (ref)
       (scm:lambda ()
-        (scm:unbox ref))))
+        (scm:unbox (scm:car ref)))))
 
   (scm:define modifyImpl
     (scm:lambda (f)
       (scm:lambda (ref)
         (scm:lambda ()
-          (scm:let* ([t (f (scm:unbox ref))]
-                     [v (scm:hashtable-ref t "state" (scm:quote Effect.Ref:modifyImpl-CANT-GET-STATE))])
-            (scm:set-box! ref v)
-            v)))))
+          (scm:with-mutex (scm:cadr ref)
+            (scm:let* ([t (f (scm:unbox (scm:car ref)))]
+                       [v (rt:record-ref t (scm:quote state))])
+              (scm:set-box! (scm:car ref) v)
+              v))))))
 
   (scm:define write
     (scm:lambda (val)
       (scm:lambda (ref)
         (scm:lambda ()
-          (scm:set-box! ref val)))))
+          (scm:with-mutex (scm:cadr ref)
+            (scm:set-box! (scm:car ref) val))))))
 
 )


### PR DESCRIPTION
As per title, we make the `Effect.Ref` implementation thread-safe, by carrying around a mutex in each ref, and making every write exclusive on this mutex.

Tests were not running, so we re-enable them too.

We'll need to merge this before the CI in https://github.com/purescm/purescm/pull/226 can pass.