### PR TITLE
Use string cursor instead of primitive uncons

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
           nix_path: nixpkgs=channel:nixos-unstable
 
       - name: Setup PureScript dependencies
-        run: npm i --global purescript@0.15.10 spago@next purescm@next
+        run: npm i --global purescript@0.15.10 spago@next purescm@latest
 
       - name: Build source
         run: spago build


### PR DESCRIPTION
`pstring-uncons-code-point` was removed in favor of a string cursor which is much faster.