### PR TITLE
Add implementation for foreign-object

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
           nix_path: nixpkgs=channel:nixos-unstable
 
       - name: Setup PureScript dependencies
-        run: npm i --global purescript@0.15.10 spago@next purescm@latest
+        run: npm i --global purescript@0.15.10 spago@0.93.32 purescm@latest
 
       - name: Build source
         run: spago build

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ generated-docs/
 .purs*
 .psa*
 .spago
+.direnv
+.envrc

--- a/datetime/spago.yaml
+++ b/datetime/spago.yaml
@@ -17,3 +17,10 @@ package:
     - partial
     - prelude
     - tuples
+  test:
+    main: Test.Main
+    dependencies:
+      - arrays
+      - assert
+      - console
+      - effect

--- a/exceptions/src/Effect/Exception.ss
+++ b/exceptions/src/Effect/Exception.ss
@@ -16,37 +16,40 @@
             make-message-condition
             condition?
             message-condition?)
+          (only (purs runtime pstring) pstring->string string->pstring)
           (only (rnrs io ports) call-with-string-output-port)
           (only (rnrs exceptions) with-exception-handler raise-continuable)
           (only (chezscheme) format call/cc display-condition))
 
   (define showErrorImpl
     (lambda (err)
-      (if (condition? err)
-        (call-with-string-output-port
-          (lambda (p) (display-condition err p)))
-        (format "Exception: ~s" err))))
+      (string->pstring
+        (if (condition? err)
+          (call-with-string-output-port
+            (lambda (p) (display-condition err p)))
+          (format "Exception: ~s" err)))))
 
   (define error
     (lambda (msg)
-      (make-message-condition msg)))
+      (make-message-condition (pstring->string msg))))
 
   (define errorWithCause
     (lambda (msg)
       (lambda (cause)
         (condition
-          (make-message-condition msg)
+          (make-message-condition (pstring->string msg))
           cause))))
 
   (define message
     (lambda (e)
-      (if (message-condition? e)
-        (condition-message e)
-        (format "Exception: ~s" e))))
+      (string->pstring
+        (if (message-condition? e)
+          (condition-message e)
+          (format "Exception: ~s" e)))))
 
   (define name
     (lambda (e)
-      "Exception"))
+      (string->pstring "Exception")))
 
   (define stackImpl
     (lambda (just)

--- a/flake.lock
+++ b/flake.lock
@@ -34,16 +34,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1705957679,
-        "narHash": "sha256-Q8LJaVZGJ9wo33wBafvZSzapYsjOaNjP/pOnSiKVGHY=",
+        "lastModified": 1719931832,
+        "narHash": "sha256-0LD+KePCKKEb4CcPsTBOwf019wDtZJanjoKm1S8q3Do=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "9a333eaa80901efe01df07eade2c16d183761fa3",
+        "rev": "0aeab749216e4c073cece5d34bc01b79e717c3e0",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "release-23.05",
+        "ref": "nixpkgs-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -57,11 +57,11 @@
         "slimlock": "slimlock"
       },
       "locked": {
-        "lastModified": 1707830135,
-        "narHash": "sha256-m/eLM/5jZAbPQEYdFdJedSOskLFZSRMY2qJ5UbPX/mY=",
+        "lastModified": 1719849006,
+        "narHash": "sha256-0HpRwEdvAlbSka5tFLwokz2bEV+QgoGqRZ0BR/ghB6w=",
         "owner": "thomashoneyman",
         "repo": "purescript-overlay",
-        "rev": "5534d1c500b6f67516455b2ec41b5b9b87fb5964",
+        "rev": "6a00f4a8fbb42e0494a57c5da99b1375721a6c4b",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -2,9 +2,7 @@
   description = "PureScript core packages CI setup";
 
   inputs = {
-    # we are stuck on 23.05 because clang is broken on macos-x86 until macos 15:
-    # https://github.com/NixOS/nixpkgs/issues/234710
-    nixpkgs.url = "github:nixos/nixpkgs/release-23.05";
+    nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
 
     flake-compat = {
       url = "github:edolstra/flake-compat";
@@ -33,7 +31,7 @@
 
       devShells = forAllSystems (system:
         let pkgs = nixpkgsFor.${system};
-            chez = pkgs.chez-racket.overrideAttrs (final: prev: {
+            chez = pkgs.chez.overrideAttrs (final: prev: {
               postFixup = if pkgs.stdenv.isDarwin then ''
                 install_name_tool -add_rpath ${pkgs.pcre2.out}/lib $out/bin/scheme
               ''

--- a/foreign-object/spago.yaml
+++ b/foreign-object/spago.yaml
@@ -16,4 +16,10 @@ package:
   test:
     main: Test.Foreign.Object.Main
     dependencies:
+      - assert
+      - console
+      - effect
       - ordered-collections
+      - partial
+      - quickcheck
+      - transformers

--- a/foreign-object/spago.yaml
+++ b/foreign-object/spago.yaml
@@ -1,0 +1,19 @@
+package:
+  name: foreign-object
+  dependencies:
+    - arrays
+    - foldable-traversable
+    - functions
+    - gen
+    - lists
+    - maybe
+    - prelude
+    - st
+    - tailrec
+    - tuples
+    - typelevel-prelude
+    - unfoldable
+  test:
+    main: Test.Foreign.Object.Main
+    dependencies:
+      - ordered-collections

--- a/foreign-object/src/Foreign/Object.js
+++ b/foreign-object/src/Foreign/Object.js
@@ -99,6 +99,10 @@ export function _lookupST(no, yes, k, m) {
   };
 }
 
+export function fromHomogeneousImpl(r) {
+  return r;
+}
+
 export function toArrayWithKey(f) {
   return function (m) {
     var r = [];

--- a/foreign-object/src/Foreign/Object.ss
+++ b/foreign-object/src/Foreign/Object.ss
@@ -15,17 +15,27 @@
           fromHomogeneousImpl
           toArrayWithKey
           keys)
-  (import (only (rnrs base) define lambda if let let-values begin)
+  (import (only (rnrs base) define lambda if let let* let-values begin)
           (prefix (chezscheme) scm:)
+          (prefix (purs runtime) rt:)
           (prefix (purs runtime srfi :214) arrays:)
-          (only (purs runtime pstring) pstring->string string->pstring))
+          (only (purs runtime pstring) pstring->symbol string->pstring))
+
+  (define symbol->pstring
+    (lambda (s)
+      (string->pstring (scm:symbol->string s))))
 
   (define _copyST
     (lambda (m)
       (lambda ()
-        (scm:hashtable-copy m #t))))
+        (scm:cons
+          (scm:hashtable-copy (scm:car m) #t)
+          (scm:list-copy (scm:cdr m))))))
 
-  (define empty (scm:make-hashtable scm:string-hash scm:string=?))
+  (define empty
+    (scm:cons
+      (scm:make-hashtable scm:symbol-hash scm:symbol=? 32)
+      (scm:quote ())))
 
   (define runST
     (lambda (f)
@@ -33,94 +43,117 @@
 
   (define _fmapObject
     (lambda (m0 f)
-      (let ([m (scm:hashtable-copy m0 #t)])
-        (scm:hash-table-for-each
-          m0
-          (lambda (k v)
-            (scm:hashtable-set! m k (f v)))))))
+      (let ([m (scm:hashtable-copy (scm:car m0) #t)])
+        (let-values ([(ks1 vs1) (scm:hashtable-entries (scm:car m0))])
+          (let loop ([ks (scm:vector->list ks1)]
+                    [vs (scm:vector->list vs1)])
+            (if (scm:null? ks)
+                (scm:cons m (scm:list-copy (scm:cdr m0)))
+                (begin
+                  (scm:symbol-hashtable-set! m (scm:car ks) (f (scm:car vs)))
+                  (loop (scm:cdr ks) (scm:cdr vs)))))))))
 
   (define _mapWithKey
     (lambda (m0 f)
-      (let ([m (scm:hashtable-copy m0 #t)])
-        (scm:hash-table-for-each
-          m0
-          (lambda (k v)
-            (scm:hashtable-set! m k ((f (string->pstring k)) v)))))))
+      (let ([m (scm:hashtable-copy (scm:car m0) #t)])
+        (let-values ([(ks1 vs1) (scm:hashtable-entries (scm:car m0))])
+          (let loop ([ks (scm:vector->list ks1)]
+                    [vs (scm:vector->list vs1)])
+            (if (scm:null? ks)
+                (scm:cons m (scm:list-copy (scm:cdr m0)))
+                (begin
+                  (scm:symbol-hashtable-set! m (scm:car ks) ((f (symbol->pstring (scm:car ks))) (scm:car vs)))
+                  (loop (scm:cdr ks) (scm:cdr vs)))))))))
 
   (define _foldM
     (lambda (bind)
       (lambda (f)
         (lambda (mz)
-          (scm:trace-lambda foldMtrace (m)
-            (let-values ([(ks vs) (scm:hashtable-entries m)])
-              (let ([g (lambda (k)
-                        (lambda (z)
-                          (((f z) (string->pstring k)) (scm:hashtable-ref m k #f))))])
-                (let loop ([ks (scm:vector->list ks)]
-                          [vs (scm:vector->list vs)]
-                          [acc mz])
-                  (if (scm:null? ks)
-                      acc
-                      (loop (scm:cdr ks) (scm:cdr vs) ((bind acc) (g (scm:car ks)))))))))))))
+          (lambda (m)
+            (let ([ks1 (scm:reverse (scm:cdr m))]
+                  [g (lambda (k)
+                      (lambda (z)
+                        (((f z) (symbol->pstring k)) (scm:symbol-hashtable-ref (scm:car m) k #f))))])
+              (let loop ([ks ks1]
+                        [acc mz])
+                (if (scm:null? ks)
+                  acc
+                  (loop (scm:cdr ks) ((bind acc) (g (scm:car ks))))))))))))
 
-  (define _foldSCObject 7)
+  (define _foldSCObject
+    (lambda (m z f fromMaybe)
+      (let ([ks1 (scm:reverse (scm:cdr m))])
+        (let loop ([ks ks1]
+                  [acc z])
+          (if (scm:null? ks)
+            acc
+            (let* ([k (scm:car ks)]
+                  [v (scm:symbol-hashtable-ref (scm:car m) k #f)]
+                  [maybeR (((f acc) (symbol->pstring k)) v)]
+                  [r ((fromMaybe (scm:quote undefined)) maybeR)])
+              (if (scm:eq? r (scm:quote undefined))
+                acc
+                (loop (scm:cdr ks) r))))))))
 
   (define all
     (lambda (f)
-      (scm:trace-lambda alltrace (m)
-        (let-values ([(ks vs) (scm:hashtable-entries m)])
+      (lambda (m)
+        (let-values ([(ks vs) (scm:hashtable-entries (scm:car m))])
           (let loop ([ks (scm:vector->list ks)]
                     [vs (scm:vector->list vs)])
             (if (scm:null? ks)
                 #t
-                (if ((f (string->pstring (scm:car ks))) (scm:car vs))
+                (if ((f (symbol->pstring (scm:car ks))) (scm:car vs))
                     (loop (scm:cdr ks) (scm:cdr vs))
                     #f)))))))
 
   (define size
     (lambda (m)
-      (scm:hashtable-size m)))
+      (scm:hashtable-size (scm:car m))))
 
   (define _lookup
     (lambda (no yes k m)
-      (if (scm:hashtable-contains? m (pstring->string k))
-          (yes (scm:hashtable-ref m (pstring->string k) #f))
+      (if (scm:symbol-hashtable-contains? (scm:car m) (pstring->symbol k))
+          (yes (scm:symbol-hashtable-ref (scm:car m) (pstring->symbol k) #f))
           no)))
 
   (define _lookupST
     (lambda (no yes k m)
       (lambda ()
-        (if (scm:hashtable-contains? m (pstring->string k))
-            (yes (scm:hashtable-ref m (pstring->string k) #f))
+        (if (scm:symbol-hashtable-contains? (scm:car m) (pstring->symbol k))
+            (yes (scm:symbol-hashtable-ref (scm:car m) (pstring->symbol k) #f))
             no))))
 
   (define fromHomogeneousImpl
     (lambda (r)
-      (let loop ([r r] [acc (scm:make-hashtable scm:string-hash scm:string=?)])
+      (let loop ([r r]
+                [ht (scm:make-hashtable scm:symbol-hash scm:symbol=?)]
+                [ks (scm:quote ())])
         (if (scm:null? r)
-            acc
+            (scm:cons ht ks)
             (let ([k (scm:caar r)]
                   [v (scm:cdar r)])
-              (scm:hashtable-set! acc (scm:symbol->string k) v)
-              (loop (scm:cdr r) acc))))))
+              (scm:symbol-hashtable-set! ht k v)
+              (loop (scm:cdr r) ht (scm:cons k ks)))))))
 
   (define toArrayWithKey
-    (scm:trace-lambda toArrayWithKey1 (f)
-      (scm:trace-lambda toArrayWithKey2 (m)
-        (let-values ([(ks vs) (scm:hashtable-entries m)])
-          (let loop ([ks (scm:vector->list ks)]
-                    [vs (scm:vector->list vs)]
+    (lambda (f)
+      (lambda (m)
+        (let ([ks1 (scm:reverse (scm:cdr m))])
+          (let loop ([ks ks1]
+                    [vs (scm:map (lambda (k) (scm:symbol-hashtable-ref (scm:car m) k #f)) ks1)]
                     [i 0]
-                    [acc (arrays:make-flexvector (scm:hashtable-size m))])
+                    [acc (arrays:make-flexvector (scm:length ks1))])
             (if (scm:null? ks)
-                acc
-                (begin
-                  (arrays:flexvector-set! acc i ((f (string->pstring (scm:car ks))) (scm:car vs)))
-                  (loop (scm:cdr ks) (scm:cdr vs) (scm:+ i 1) acc))))))))
+              acc
+              (begin
+                (arrays:flexvector-set! acc i ((f (symbol->pstring (scm:car ks))) (scm:car vs)))
+                (loop (scm:cdr ks) (scm:cdr vs) (scm:+ i 1) acc))))))))
 
   (define keys
     (lambda (m)
-      (arrays:flexvector-map! (lambda (k) (string->pstring k))
-        (arrays:vector->flexvector
-          (scm:hashtable-keys m)))))
+      (arrays:list->flexvector
+        (scm:map
+          symbol->pstring
+          (scm:reverse (scm:cdr m))))))
 )

--- a/foreign-object/src/Foreign/Object.ss
+++ b/foreign-object/src/Foreign/Object.ss
@@ -119,14 +119,14 @@
       (lambda (m)
         (let* ([len (scm:length (scm:unbox m))]
               [arr (arrays:make-flexvector len)])
-          (let loop ([i (scm:- len 1)]
+          (let loop ([i (scm:fx- len 1)]
                     [els (scm:unbox m)])
             (if (scm:null? els)
               arr
               (begin
                 (let ([el (scm:car els)])
                   (arrays:flexvector-set! arr i ((f (symbol->pstring (scm:car el))) (scm:cdr el))))
-                (loop (scm:- i 1) (scm:cdr els)))))))))
+                (loop (scm:fx- i 1) (scm:cdr els)))))))))
 
   (define keys
     (lambda (m)

--- a/foreign-object/src/Foreign/Object.ss
+++ b/foreign-object/src/Foreign/Object.ss
@@ -1,0 +1,126 @@
+;; -*- mode: scheme -*-
+
+(library (Foreign.Object foreign)
+  (export _copyST
+          empty
+          runST
+          _fmapObject
+          _mapWithKey
+          _foldM
+          _foldSCObject
+          all
+          size
+          _lookup
+          _lookupST
+          fromHomogeneousImpl
+          toArrayWithKey
+          keys)
+  (import (only (rnrs base) define lambda if let let-values begin)
+          (prefix (chezscheme) scm:)
+          (prefix (purs runtime srfi :214) arrays:)
+          (only (purs runtime pstring) pstring->string string->pstring))
+
+  (define _copyST
+    (lambda (m)
+      (lambda ()
+        (scm:hashtable-copy m #t))))
+
+  (define empty (scm:make-hashtable scm:string-hash scm:string=?))
+
+  (define runST
+    (lambda (f)
+      (f)))
+
+  (define _fmapObject
+    (lambda (m0 f)
+      (let ([m (scm:hashtable-copy m0 #t)])
+        (scm:hash-table-for-each
+          m0
+          (lambda (k v)
+            (scm:hashtable-set! m k (f v)))))))
+
+  (define _mapWithKey
+    (lambda (m0 f)
+      (let ([m (scm:hashtable-copy m0 #t)])
+        (scm:hash-table-for-each
+          m0
+          (lambda (k v)
+            (scm:hashtable-set! m k ((f (string->pstring k)) v)))))))
+
+  (define _foldM
+    (lambda (bind)
+      (lambda (f)
+        (lambda (mz)
+          (scm:trace-lambda foldMtrace (m)
+            (let-values ([(ks vs) (scm:hashtable-entries m)])
+              (let ([g (lambda (k)
+                        (lambda (z)
+                          (((f z) (string->pstring k)) (scm:hashtable-ref m k #f))))])
+                (let loop ([ks (scm:vector->list ks)]
+                          [vs (scm:vector->list vs)]
+                          [acc mz])
+                  (if (scm:null? ks)
+                      acc
+                      (loop (scm:cdr ks) (scm:cdr vs) ((bind acc) (g (scm:car ks)))))))))))))
+
+  (define _foldSCObject 7)
+
+  (define all
+    (lambda (f)
+      (scm:trace-lambda alltrace (m)
+        (let-values ([(ks vs) (scm:hashtable-entries m)])
+          (let loop ([ks (scm:vector->list ks)]
+                    [vs (scm:vector->list vs)])
+            (if (scm:null? ks)
+                #t
+                (if ((f (string->pstring (scm:car ks))) (scm:car vs))
+                    (loop (scm:cdr ks) (scm:cdr vs))
+                    #f)))))))
+
+  (define size
+    (lambda (m)
+      (scm:hashtable-size m)))
+
+  (define _lookup
+    (lambda (no yes k m)
+      (if (scm:hashtable-contains? m (pstring->string k))
+          (yes (scm:hashtable-ref m (pstring->string k) #f))
+          no)))
+
+  (define _lookupST
+    (lambda (no yes k m)
+      (lambda ()
+        (if (scm:hashtable-contains? m (pstring->string k))
+            (yes (scm:hashtable-ref m (pstring->string k) #f))
+            no))))
+
+  (define fromHomogeneousImpl
+    (lambda (r)
+      (let loop ([r r] [acc (scm:make-hashtable scm:string-hash scm:string=?)])
+        (if (scm:null? r)
+            acc
+            (let ([k (scm:caar r)]
+                  [v (scm:cdar r)])
+              (scm:hashtable-set! acc (scm:symbol->string k) v)
+              (loop (scm:cdr r) acc))))))
+
+  (define toArrayWithKey
+    (scm:trace-lambda toArrayWithKey1 (f)
+      (scm:trace-lambda toArrayWithKey2 (m)
+        (let-values ([(ks vs) (scm:hashtable-entries m)])
+          (let loop ([ks (scm:vector->list ks)]
+                    [vs (scm:vector->list vs)]
+                    [i 0]
+                    [acc (arrays:make-flexvector (scm:hashtable-size m))])
+            (if (scm:null? ks)
+                acc
+                (begin
+                  (arrays:flexvector-set! acc i ((f (string->pstring (scm:car ks))) (scm:car vs)))
+                  (loop (scm:cdr ks) (scm:cdr vs) (scm:+ i 1) acc))))))))
+
+  (define keys
+    (lambda (m)
+      (arrays:flexvector-map! (lambda (k) (string->pstring k))
+        (arrays:vector->flexvector
+          (scm:hashtable-keys m)))))
+)

--- a/foreign-object/src/Foreign/Object/ST.ss
+++ b/foreign-object/src/Foreign/Object/ST.ss
@@ -5,13 +5,27 @@
           peekImpl
           poke
           delete)
-  (import (only (rnrs base) define lambda if)
+  (import (only (rnrs base) define lambda if let)
           (prefix (chezscheme) scm:)
-          (only (purs runtime pstring) pstring->string))
+          (prefix (purs runtime) rt:)
+          (only (purs runtime pstring) pstring->symbol))
+
+  (define remove-1st
+    (lambda (x ls)
+      (if (scm:null? ls)                 ; If an empty list
+        (scm:quote ())                   ; Return an empty list
+        (if (scm:equal? x (scm:car ls))  ; Otherwise, if first item in list
+          (scm:cdr ls)                   ; Return rest of list, done
+          (scm:cons (scm:car ls) (remove-1st x (scm:cdr ls)))))))
+          ; Otherwise, cons first item and
+          ; rest of list with our item removed
+
 
   (define new
     (lambda ()
-      (scm:make-hashtable scm:string-hash scm:string=?)))
+      (scm:cons
+        (scm:make-hashtable scm:symbol-hash scm:symbol=? 32)
+        (scm:quote ()))))
 
   (define peekImpl
     (lambda (just)
@@ -19,8 +33,8 @@
         (lambda (k)
           (lambda (m)
             (lambda ()
-              (if (scm:hashtable-contains? m (pstring->string k))
-                  (just (scm:hashtable-ref m (pstring->string k) #f))
+              (if (scm:symbol-hashtable-contains? (scm:car m) (pstring->symbol k))
+                  (just (scm:symbol-hashtable-ref (scm:car m) (pstring->symbol k) #f))
                   nothing)))))))
 
   (define poke
@@ -28,13 +42,15 @@
       (lambda (v)
         (lambda (m)
           (lambda ()
-            (scm:hashtable-set! m (pstring->string k) v)
+            (scm:symbol-hashtable-set! (scm:car m) (pstring->symbol k) v)
+            (scm:set-cdr! m (scm:cons (pstring->symbol k) (scm:cdr m)))
             m)))))
 
   (define delete
     (lambda (k)
       (lambda (m)
         (lambda ()
-          (scm:hashtable-delete! m (pstring->string k))
+          (scm:symbol-hashtable-delete! (scm:car m) (pstring->symbol k))
+          (scm:set-cdr! m (remove-1st (pstring->symbol k) (scm:cdr m)))
           m))))
 )

--- a/foreign-object/src/Foreign/Object/ST.ss
+++ b/foreign-object/src/Foreign/Object/ST.ss
@@ -23,9 +23,7 @@
 
   (define new
     (lambda ()
-      (scm:cons
-        (scm:make-hashtable scm:symbol-hash scm:symbol=? 32)
-        (scm:quote ()))))
+      (scm:box (scm:quote ()))))
 
   (define peekImpl
     (lambda (just)
@@ -33,8 +31,8 @@
         (lambda (k)
           (lambda (m)
             (lambda ()
-              (if (scm:symbol-hashtable-contains? (scm:car m) (pstring->symbol k))
-                  (just (scm:symbol-hashtable-ref (scm:car m) (pstring->symbol k) #f))
+              (if (rt:record-has (scm:unbox m) (pstring->symbol k))
+                  (just (rt:record-ref (scm:unbox m) (pstring->symbol k)))
                   nothing)))))))
 
   (define poke
@@ -42,15 +40,15 @@
       (lambda (v)
         (lambda (m)
           (lambda ()
-            (scm:symbol-hashtable-set! (scm:car m) (pstring->symbol k) v)
-            (scm:set-cdr! m (scm:cons (pstring->symbol k) (scm:cdr m)))
-            m)))))
+            (let ([new-m (rt:record-set (scm:unbox m) (pstring->symbol k) v)])
+              (scm:set-box! m new-m)
+              m))))))
 
   (define delete
     (lambda (k)
       (lambda (m)
         (lambda ()
-          (scm:symbol-hashtable-delete! (scm:car m) (pstring->symbol k))
-          (scm:set-cdr! m (remove-1st (pstring->symbol k) (scm:cdr m)))
-          m))))
+          (let ([new-m (rt:record-remove (scm:unbox m) (pstring->symbol k))])
+            (scm:set-box! m new-m)
+            m)))))
 )

--- a/foreign-object/src/Foreign/Object/ST.ss
+++ b/foreign-object/src/Foreign/Object/ST.ss
@@ -1,0 +1,40 @@
+;; -*- mode: scheme -*-
+
+(library (Foreign.Object.ST foreign)
+  (export new
+          peekImpl
+          poke
+          delete)
+  (import (only (rnrs base) define lambda if)
+          (prefix (chezscheme) scm:)
+          (only (purs runtime pstring) pstring->string))
+
+  (define new
+    (lambda ()
+      (scm:make-hashtable scm:string-hash scm:string=?)))
+
+  (define peekImpl
+    (lambda (just)
+      (lambda (nothing)
+        (lambda (k)
+          (lambda (m)
+            (lambda ()
+              (if (scm:hashtable-contains? m (pstring->string k))
+                  (just (scm:hashtable-ref m (pstring->string k) #f))
+                  nothing)))))))
+
+  (define poke
+    (lambda (k)
+      (lambda (v)
+        (lambda (m)
+          (lambda ()
+            (scm:hashtable-set! m (pstring->string k) v)
+            m)))))
+
+  (define delete
+    (lambda (k)
+      (lambda (m)
+        (lambda ()
+          (scm:hashtable-delete! m (pstring->string k))
+          m))))
+)

--- a/foreign-object/src/Foreign/Object/ST/Unsafe.ss
+++ b/foreign-object/src/Foreign/Object/ST/Unsafe.ss
@@ -1,0 +1,11 @@
+;; -*- mode: scheme -*-
+
+(library (Foreign.Object.ST foreign)
+  (export unsafeFreeze)
+  (import (only (rnrs base) define lambda))
+
+  (define unsafeFreeze
+    (lambda (m)
+      (lambda ()
+        m)))
+)

--- a/foreign-object/src/Foreign/Object/Unsafe.ss
+++ b/foreign-object/src/Foreign/Object/Unsafe.ss
@@ -1,0 +1,15 @@
+;; -*- mode: scheme -*-
+
+(library (Foreign.Object.Unsafe foreign)
+  (export unsafeIndex)
+  (import (only (rnrs base) define lambda if)
+          (prefix (chezscheme) scm:)
+          (only (purs runtime pstring) pstring->string))
+
+  (define unsafeIndex
+    (lambda (m)
+      (lambda (k)
+        (if (scm:hashtable-contains? m (pstring->string k))
+            (scm:hashtable-ref m (pstring->string k) #f)
+            (scm:raise (scm:condition (scm:make-error) (scm:make-message-condition "unsafeIndex: key not found")))))))
+)

--- a/foreign-object/src/Foreign/Object/Unsafe.ss
+++ b/foreign-object/src/Foreign/Object/Unsafe.ss
@@ -4,12 +4,12 @@
   (export unsafeIndex)
   (import (only (rnrs base) define lambda if)
           (prefix (chezscheme) scm:)
-          (only (purs runtime pstring) pstring->string))
+          (only (purs runtime pstring) pstring->symbol))
 
   (define unsafeIndex
     (lambda (m)
       (lambda (k)
-        (if (scm:hashtable-contains? m (pstring->string k))
-            (scm:hashtable-ref m (pstring->string k) #f)
+        (if (scm:symbol-hashtable-contains? (scm:car m) (pstring->symbol k))
+            (scm:symbol-hashtable-ref (scm:car m) (pstring->symbol k) #f)
             (scm:raise (scm:condition (scm:make-error) (scm:make-message-condition "unsafeIndex: key not found")))))))
 )

--- a/foreign-object/src/Foreign/Object/Unsafe.ss
+++ b/foreign-object/src/Foreign/Object/Unsafe.ss
@@ -4,12 +4,13 @@
   (export unsafeIndex)
   (import (only (rnrs base) define lambda if)
           (prefix (chezscheme) scm:)
+          (prefix (purs runtime) rt:)
           (only (purs runtime pstring) pstring->symbol))
 
   (define unsafeIndex
     (lambda (m)
       (lambda (k)
-        (if (scm:symbol-hashtable-contains? (scm:car m) (pstring->symbol k))
-            (scm:symbol-hashtable-ref (scm:car m) (pstring->symbol k) #f)
+        (if (rt:record-has (scm:unbox m) (pstring->symbol k))
+            (rt:record-ref (scm:unbox m) (pstring->symbol k))
             (scm:raise (scm:condition (scm:make-error) (scm:make-message-condition "unsafeIndex: key not found")))))))
 )

--- a/foreign-object/test/Test/Foreign/Object.purs
+++ b/foreign-object/test/Test/Foreign/Object.purs
@@ -18,7 +18,9 @@ import Data.Traversable (sequence, traverse)
 import Data.TraversableWithIndex (traverseWithIndex)
 import Data.Tuple (Tuple(..), fst, snd, uncurry)
 import Effect (Effect)
+import Effect.Class.Console (logShow)
 import Effect.Console (log)
+import Effect.Unsafe (unsafePerformEffect)
 import Foreign.Object as O
 import Foreign.Object.Gen (genForeignObject)
 import Partial.Unsafe (unsafePartial)
@@ -69,8 +71,12 @@ toAscArray = O.toAscUnfoldable
 objectTests :: Effect Unit
 objectTests = do
   log "Test inserting into empty tree"
-  quickCheck $ \k v -> O.lookup k (O.insert k v O.empty) == Just (number v)
-    <?> ("k: " <> show k <> ", v: " <> show v)
+  quickCheck $
+    ( \k v -> unsafePerformEffect do
+        logShow k
+        pure $ O.lookup k (O.insert k v O.empty) == Just (number v)
+          <?> ("k: " <> show k <> ", v: " <> show v)
+    )
 
   log "Test inserting two values with same key"
   quickCheck $ \k v1 v2 ->

--- a/foreign-object/test/Test/Main.purs
+++ b/foreign-object/test/Test/Main.purs
@@ -18,8 +18,8 @@ example = do
     -- insert to an empty Object
     inserted = FO.insert "a" 1 empty
 
-    -- or: use the singleton function
-    -- singleton FO.singleton "a" 1
+  -- or: use the singleton function
+  -- singleton FO.singleton "a" 1
 
   -- lookup values for existing in the Object as a result of Maybe
   let lookup = FO.lookup "a" inserted
@@ -31,10 +31,9 @@ example = do
 
   let
     -- convert homogeneous records to Object
-    converted = FO.fromHomogeneous { a: 1, b: 2, c: 3}
+    converted = FO.fromHomogeneous { a: 1, b: 2, c: 3 }
     -- check that the converted is equal to a regularly built Object
-    built
-      = FO.empty
+    built = FO.empty
       # FO.insert "a" 1
       # FO.insert "b" 2
       # FO.insert "c" 3
@@ -45,4 +44,5 @@ main :: Effect Unit
 main = do
   log "Running StrMap tests"
   example
+  log "Running Object tests"
   objectTests

--- a/foreign-object/test/Test/Main.purs
+++ b/foreign-object/test/Test/Main.purs
@@ -1,4 +1,4 @@
-module Test.Main where
+module Test.Foreign.Object.Main where
 
 import Prelude
 

--- a/partial/src/Partial.ss
+++ b/partial/src/Partial.ss
@@ -2,10 +2,11 @@
 
 (library (Partial foreign)
   (export _crashWith)
-  (import (only (rnrs base) define lambda error))
+  (import (only (rnrs base) define lambda error)
+          (only (purs runtime pstring) pstring->string))
 
   (define _crashWith
     (lambda (msg)
-      (error #f msg)))
+      (error #f (pstring->string msg))))
 
 )

--- a/prelude/src/Data/Show.ss
+++ b/prelude/src/Data/Show.ss
@@ -45,7 +45,7 @@
                                [(char=? c #\return) (pstring #\\ #\r)]
                                [(char=? c #\tab) (pstring #\\ #\t)]
                                [(char=? c #\vtab) (pstring #\\ #\v)]
-                               [else c])))])
+                               [else (pstring c)])))])
         (pstring-concat
           (pstring #\")
           (pstring-regex-replace-by regex s replacement)

--- a/quickcheck/src/Test/QuickCheck/Arbitrary.purs
+++ b/quickcheck/src/Test/QuickCheck/Arbitrary.purs
@@ -17,7 +17,7 @@ import Control.Monad.Gen.Class (chooseBool)
 import Control.Monad.Gen.Common as MGC
 import Control.Monad.ST as ST
 import Data.Array ((:))
-import Data.Array.NonEmpty (NonEmptyArray)
+import Data.Array.NonEmpty (NonEmptyArray, cons')
 import Data.Array.NonEmpty as NEA
 import Data.Array.ST as STA
 import Data.Either (Either(..))
@@ -106,7 +106,8 @@ instance coarbNonEmptyString :: Coarbitrary NonEmptyString where
   coarbitrary = coarbitrary <<< NES.toString
 
 instance arbChar :: Arbitrary Char where
-  arbitrary = toEnumWithDefaults bottom top <$> chooseInt 0 65536
+  arbitrary = toEnumWithDefaults bottom top <$> oneOf
+    (cons' (chooseInt 0 55295) [ chooseInt 57344 65536 ])
 
 instance coarbChar :: Coarbitrary Char where
   coarbitrary c = coarbitrary $ fromEnum c

--- a/spago.lock
+++ b/spago.lock
@@ -219,6 +219,63 @@ workspace:
         - tuples
         - type-equality
         - unsafe-coerce
+    foreign-object:
+      path: foreign-object
+      dependencies:
+        - arrays
+        - foldable-traversable
+        - functions
+        - gen
+        - lists
+        - maybe
+        - prelude
+        - st
+        - tailrec
+        - tuples
+        - typelevel-prelude
+        - unfoldable
+      test_dependencies:
+        - ordered-collections
+      build_plan:
+        - arrays
+        - assert
+        - bifunctors
+        - console
+        - const
+        - contravariant
+        - control
+        - distributive
+        - effect
+        - either
+        - exists
+        - foldable-traversable
+        - functions
+        - functors
+        - gen
+        - identity
+        - integers
+        - invariant
+        - lazy
+        - lists
+        - maybe
+        - minibench
+        - newtype
+        - nonempty
+        - numbers
+        - ordered-collections
+        - orders
+        - partial
+        - prelude
+        - profunctor
+        - refs
+        - safe-coerce
+        - st
+        - tailrec
+        - tuples
+        - type-equality
+        - typelevel-prelude
+        - unfoldable
+        - unsafe-coerce
     functions:
       path: functions
       dependencies:

--- a/spago.lock
+++ b/spago.lock
@@ -90,6 +90,69 @@ workspace:
         - prelude
         - safe-coerce
         - unsafe-coerce
+    datetime:
+      path: datetime
+      dependencies:
+        - bifunctors
+        - control
+        - either
+        - enums
+        - foldable-traversable
+        - functions
+        - gen
+        - integers
+        - lists
+        - maybe
+        - newtype
+        - numbers
+        - ordered-collections
+        - partial
+        - prelude
+        - tuples
+      test_dependencies:
+        - arrays
+        - assert
+        - console
+        - effect
+      build_plan:
+        - arrays
+        - assert
+        - bifunctors
+        - console
+        - const
+        - contravariant
+        - control
+        - distributive
+        - effect
+        - either
+        - enums
+        - exists
+        - foldable-traversable
+        - functions
+        - functors
+        - gen
+        - identity
+        - integers
+        - invariant
+        - lazy
+        - lists
+        - maybe
+        - newtype
+        - nonempty
+        - numbers
+        - ordered-collections
+        - orders
+        - partial
+        - prelude
+        - profunctor
+        - refs
+        - safe-coerce
+        - st
+        - tailrec
+        - tuples
+        - type-equality
+        - unfoldable
+        - unsafe-coerce
     effect:
       path: effect
       dependencies:
@@ -231,7 +294,13 @@ workspace:
         - typelevel-prelude
         - unfoldable
       test_dependencies:
+        - assert
+        - console
+        - effect
         - ordered-collections
+        - partial
+        - quickcheck
+        - transformers
       build_plan:
         - arrays
         - assert
@@ -243,6 +312,8 @@ workspace:
         - distributive
         - effect
         - either
+        - enums
+        - exceptions
         - exists
         - foldable-traversable
         - functions
@@ -252,9 +323,9 @@ workspace:
         - integers
         - invariant
         - lazy
+        - lcg
         - lists
         - maybe
-        - minibench
         - newtype
         - nonempty
         - numbers
@@ -263,10 +334,15 @@ workspace:
         - partial
         - prelude
         - profunctor
+        - quickcheck
+        - random
+        - record
         - refs
         - safe-coerce
         - st
+        - strings
         - tailrec
+        - transformers
         - tuples
         - type-equality
         - typelevel-prelude
@@ -1353,6 +1429,22 @@ packages:
       - prelude
       - tuples
       - unfoldable
+  ordered-collections:
+    type: registry
+    version: 3.1.1
+    integrity: sha256-boSYHmlz4aSbwsNN4VxiwCStc0t+y1F7BXmBS+1JNtI=
+    dependencies:
+      - arrays
+      - foldable-traversable
+      - gen
+      - lists
+      - maybe
+      - partial
+      - prelude
+      - st
+      - tailrec
+      - tuples
+      - unfoldable
   orders:
     type: registry
     version: 6.0.0
@@ -1424,3 +1516,10 @@ packages:
     version: 4.0.1
     integrity: sha256-Hs9D6Y71zFi/b+qu5NSbuadUQXe5iv5iWx0226vOHUw=
     dependencies: []
+  typelevel-prelude:
+    type: registry
+    version: 7.0.0
+    integrity: sha256-uFF2ph+vHcQpfPuPf2a3ukJDFmLhApmkpTMviHIWgJM=
+    dependencies:
+      - prelude
+      - type-equality

--- a/test.sh
+++ b/test.sh
@@ -60,4 +60,7 @@ purescm run --main Test.Record.Main
 echo "Testing quickcheck"
 purescm run --main Test.QuickCheck.Main
 
+echo "Test foreign-object"
+purescm run --main Test.Foreign.Object.Main
+
 echo "All good!"


### PR DESCRIPTION
This PR adds FFI for foreign-object using a symbol-hashtable together with a list to keep track of insertion order, which is an invariant of the JS implementation.

It's not strictly needed for Scheme, but it's good to have for compatibility with existing JS-backend code.

There is one slow test that I need to look more into, but the patch passes all tests otherwise.