### PR TITLE
Fix Effect.Ref.modify' by returning the correct record instead of just returning the new state

### DIFF
--- a/refs/src/Effect/Ref.ss
+++ b/refs/src/Effect/Ref.ss
@@ -34,7 +34,7 @@
             (scm:let* ([t (f (scm:unbox (scm:car ref)))]
                        [v (rt:record-ref t (scm:quote state))])
               (scm:set-box! (scm:car ref) v)
-              v))))))
+              (rt:record-ref t (scm:quote value))))))))
 
   (scm:define write
     (scm:lambda (val)

--- a/refs/test/Main.purs
+++ b/refs/test/Main.purs
@@ -29,6 +29,12 @@ main = do
   curr3 <- Ref.read ref
   assertEqual { actual: curr3, expected: 2 }
 
+  -- modify it by adding 1 to the current state, but this time we want to see the value
+  previous <- Ref.modify' (\s -> { state: s + 1, value: s }) ref
+  assertEqual { actual: previous, expected: curr3 }
+  curr4 <- Ref.read ref
+  assertEqual { actual: curr4, expected: 3 }
+
   selfRef
 
 newtype RefBox = RefBox { ref :: Ref.Ref RefBox, value :: Int }


### PR DESCRIPTION
We also add a test to the suite, which was missing tests for this function.